### PR TITLE
Adds iAP2 BT/USB connection emulation over TCP transport

### DIFF
--- a/src/components/transport_manager/CMakeLists.txt
+++ b/src/components/transport_manager/CMakeLists.txt
@@ -92,6 +92,13 @@ else()
   )
 endif()
 
+if(NOT BUILD_TESTS)
+  list (APPEND EXCLUDE_PATH
+    ${CMAKE_CURRENT_SOURCE_DIR}/include/iap2_emulation/iap2_transport_adapter.h
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/iap2_emulation/iap2_transport_adapter.cc
+  )
+endif()
+
 collect_sources(SOURCES "${PATHS}" "${EXCLUDE_PATHS}")
 
 add_library("TransportManager" ${SOURCES})

--- a/src/components/transport_manager/include/transport_manager/iap2_emulation/iap2_transport_adapter.h
+++ b/src/components/transport_manager/include/transport_manager/iap2_emulation/iap2_transport_adapter.h
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2017, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "transport_manager/tcp/tcp_transport_adapter.h"
+#include "transport_manager/transport_manager_settings.h"
+#include "resumption/last_state.h"
+#include "utils/macro.h"
+
+namespace transport_manager {
+namespace transport_adapter {
+
+/**
+ * @brief The IAP2BluetoothEmulationTransportAdapter class implements iAP2
+ * Bluetooth transport over TCP
+ */
+class IAP2BluetoothEmulationTransportAdapter : public TcpTransportAdapter {
+ public:
+  /**
+   * @brief IAP2BluetoothEmulationTransportAdapter constructor
+   * @param port TCP port to listen on
+   * @param last_state LastState instance reference
+   * @param settings Settings reference
+   */
+  IAP2BluetoothEmulationTransportAdapter(
+      const uint16_t port,
+      resumption::LastState& last_state,
+      const TransportManagerSettings& settings);
+
+  /**
+   * @brief DeviceSwitched is called during switching from iAP2 Bluetooth to
+   * iAP2 USB transport.
+   * Currently there is no logic to switch back from iAP2 USB to iAP2 Bluetooth
+   * due to Bluetooth reconnection takes much time and this violates some Apple
+   * restrictions for iAP2 protocol, so if this method will be called - assert
+   * will be called
+   * @param device_handle Device handle of switched device
+   */
+  void DeviceSwitched(const DeviceUID& device_handle) OVERRIDE;
+
+ protected:
+  /**
+   * @brief GetDeviceType Provides SDL device type for transport adapter
+   * @return Device type
+   */
+  DeviceType GetDeviceType() const OVERRIDE;
+};
+
+/**
+ * @brief The IAP2USBEmulationTransportAdapter class implements emulation of
+ * iAP2 USB transport over TCP
+ */
+class IAP2USBEmulationTransportAdapter : public TcpTransportAdapter {
+ public:
+  /**
+   * @brief IAP2USBEmulationTransportAdapter constructor
+   * @param port TCP port to listen on
+   * @param last_state LastState instance reference
+   * @param settings Settings reference
+   */
+  IAP2USBEmulationTransportAdapter(const uint16_t port,
+                                   resumption::LastState& last_state,
+                                   const TransportManagerSettings& settings);
+
+  /**
+   * @brief DeviceSwitched is called during switching from iAP2 Bluetooth to
+   * iAP2 USB transport
+   * @param device_handle Device handle of switched device
+   */
+  void DeviceSwitched(const DeviceUID& device_handle) OVERRIDE;
+
+ protected:
+  /**
+   * @brief GetDeviceType Provides SDL device type for transport adapter
+   * @return Device type
+   */
+  DeviceType GetDeviceType() const OVERRIDE;
+};
+}
+}  // namespace transport_manager::transport_adapter

--- a/src/components/transport_manager/include/transport_manager/transport_adapter/transport_adapter_impl.h
+++ b/src/components/transport_manager/include/transport_manager/transport_adapter/transport_adapter_impl.h
@@ -413,7 +413,7 @@ class TransportAdapterImpl : public TransportAdapter,
    * Stop() interface of that device
    * @param device_id unique device identifier that has to be stopped.
    */
-  void StopDevice(const DeviceUID& device_id) const FINAL;
+  void StopDevice(const DeviceUID& device_id) const OVERRIDE;
 
   /**
    * @brief DeviceSwitched is triggered for adapter to proceed with possible
@@ -422,7 +422,7 @@ class TransportAdapterImpl : public TransportAdapter,
    * This is default implemenation does nothing. Must be overloaded if needed.
    * @param device_handle Device id to notify on event
    */
-  void DeviceSwitched(const DeviceUID& device_handle) FINAL;
+  void DeviceSwitched(const DeviceUID& device_handle) OVERRIDE;
 
   /**
    * @brief Allows to obtain connection type used by device.

--- a/src/components/transport_manager/src/iap2_emulation/iap2_transport_adapter.cc
+++ b/src/components/transport_manager/src/iap2_emulation/iap2_transport_adapter.cc
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2017, Ford Motor Company
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice, this
+ * list of conditions and the following disclaimer.
+ *
+ * Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following
+ * disclaimer in the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of the Ford Motor Company nor the names of its contributors
+ * may be used to endorse or promote products derived from this software
+ * without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "transport_manager/iap2_emulation/iap2_transport_adapter.h"
+
+namespace transport_manager {
+namespace transport_adapter {
+
+CREATE_LOGGERPTR_GLOBAL(logger_, "IAP2Emulation");
+
+IAP2BluetoothEmulationTransportAdapter::IAP2BluetoothEmulationTransportAdapter(
+    const uint16_t port,
+    resumption::LastState& last_state,
+    const TransportManagerSettings& settings)
+    : TcpTransportAdapter(port, last_state, settings) {}
+
+void IAP2BluetoothEmulationTransportAdapter::DeviceSwitched(
+    const DeviceUID& device_handle) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  UNUSED(device_handle);
+  DCHECK(!"Switching for iAP2 Bluetooth is not supported.");
+}
+
+DeviceType IAP2BluetoothEmulationTransportAdapter::GetDeviceType() const {
+  return IOS_BT;
+}
+
+IAP2USBEmulationTransportAdapter::IAP2USBEmulationTransportAdapter(
+    const uint16_t port,
+    resumption::LastState& last_state,
+    const TransportManagerSettings& settings)
+    : TcpTransportAdapter(port, last_state, settings) {}
+
+void IAP2USBEmulationTransportAdapter::DeviceSwitched(
+    const DeviceUID& device_handle) {
+  LOG4CXX_AUTO_TRACE(logger_);
+  UNUSED(device_handle);
+  LOG4CXX_DEBUG(logger_, "iAP2 USB device is switched with iAP2 Bluetooth");
+}
+
+DeviceType IAP2USBEmulationTransportAdapter::GetDeviceType() const {
+  return IOS_USB;
+}
+}
+}  // namespace transport_manager::transport_adapter

--- a/src/components/transport_manager/src/tcp/tcp_client_listener.cc
+++ b/src/components/transport_manager/src/tcp/tcp_client_listener.cc
@@ -230,6 +230,7 @@ void TcpClientListener::Loop() {
             inet_ntoa(client_address.sin_addr),
             sizeof(device_name) / sizeof(device_name[0]));
     LOG4CXX_INFO(logger_, "Connected client " << device_name);
+    LOG4CXX_INFO(logger_, "Port is: " << port_);
 
     if (enable_keepalive_) {
       SetKeepaliveOptions(connection_fd);

--- a/src/components/transport_manager/src/transport_manager_default.cc
+++ b/src/components/transport_manager/src/transport_manager_default.cc
@@ -44,6 +44,10 @@
 #include "transport_manager/usb/usb_aoa_adapter.h"
 #endif  // USB_SUPPORT
 
+#if defined(BUILD_TESTS)
+#include "transport_manager/iap2_emulation/iap2_transport_adapter.h"
+#endif  // BUILD_TEST
+
 namespace transport_manager {
 CREATE_LOGGERPTR_GLOBAL(logger_, "TransportManager")
 
@@ -96,6 +100,23 @@ int TransportManagerDefault::Init(resumption::LastState& last_state) {
   AddTransportAdapter(ta_usb);
   ta_usb = NULL;
 #endif  // USB_SUPPORT
+
+#if defined BUILD_TESTS
+  const uint16_t iap2_bt_emu_port = 23456;
+  transport_adapter::IAP2BluetoothEmulationTransportAdapter*
+      iap2_bt_emu_adapter =
+          new transport_adapter::IAP2BluetoothEmulationTransportAdapter(
+              iap2_bt_emu_port, last_state, get_settings());
+
+  AddTransportAdapter(iap2_bt_emu_adapter);
+
+  const uint16_t iap2_usb_emu_port = 34567;
+  transport_adapter::IAP2USBEmulationTransportAdapter* iap2_usb_emu_adapter =
+      new transport_adapter::IAP2USBEmulationTransportAdapter(
+          iap2_usb_emu_port, last_state, get_settings());
+
+  AddTransportAdapter(iap2_usb_emu_adapter);
+#endif  // BUILD_TEST
 
   LOG4CXX_TRACE(logger_, "exit with E_SUCCESS");
   return E_SUCCESS;


### PR DESCRIPTION
Implements emulation of iAP2 Bluetooth and USB adapters in order to be able to test transport switching logic in SDL. Implementation is done by using existing TCP transport adapter code with customized ports values: 23456 is for iAP2 Bluetooth, 34567 is for iAP2 USB so on Linux it can be tested just with TCP connection over 127.0.0.1:port.

Appropriate PR for ATF tests is https://github.com/smartdevicelink/sdl_atf_test_scripts/pull/1732